### PR TITLE
remove !important from display none on show only when printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [11.3.1] - 2021-03-02
+### Changed
+- Removed !important from display none on display only when printing
 ## [11.3.0] - 2021-02-24
 ### Added
 - Added getData option to process selectors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "11.3.0",
+    "version": "11.3.1",
     "private": false,
     "dependencies": {
         "classnames": "^2.2.6",

--- a/src/styles/printStyles.css
+++ b/src/styles/printStyles.css
@@ -47,7 +47,7 @@
 }
 
 .show-only-when-printing {
-    display: none !important;
+    display: none;
 }
 
 .padding-top-when-not-printing {

--- a/src/styles/printStyles.css
+++ b/src/styles/printStyles.css
@@ -30,7 +30,7 @@
         display: none !important;
     }
     .show-only-when-printing {
-        display: block !important;
+        visibility: visible !important;
     }
     .padding-top-when-not-printing {
         padding-top: 0 !important;
@@ -47,7 +47,7 @@
 }
 
 .show-only-when-printing {
-    display: none;
+     visibility: hidden;
 }
 
 .padding-top-when-not-printing {

--- a/src/styles/printStyles.css
+++ b/src/styles/printStyles.css
@@ -30,7 +30,7 @@
         display: none !important;
     }
     .show-only-when-printing {
-        visibility: visible !important;
+        display: block !important;
     }
     .padding-top-when-not-printing {
         padding-top: 0 !important;
@@ -47,7 +47,7 @@
 }
 
 .show-only-when-printing {
-     visibility: hidden;
+     display: none;
 }
 
 .padding-top-when-not-printing {


### PR DESCRIPTION
I'll test this when I get a chance but if you have a chance first would be worth testing locally with the npm pack thing and the .tgz,

I think the !important on display none could have meant that the display block one didn't override it
