### PR TITLE
Process failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-# Changelog
+## [12.7.0] - 2021-11-26
+### Changes
+- Flip processStore working flag to false if the process request errors unexpectedly.
+
 ## [12.5.0] - 2021-11-10
 ### Changes
 - Upped react version in dependencies (peer dependencies already was) to react 17

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "12.6.0",
+    "version": "12.7.0",
     "private": false,
     "dependencies": {
         "classnames": "^2.2.6",

--- a/src/reducers/__tests__/processStoreFactory.js
+++ b/src/reducers/__tests__/processStoreFactory.js
@@ -5,7 +5,8 @@ describe('item store reducer factory', () => {
     const actionTypes = {
         REQUEST_PROCESS: 'REQUEST_PROCESS',
         RECEIVE_PROCESS: 'RECEIVE_PROCESS',
-        CLEAR_PROCESS_DATA: 'CLEAR_PROCESS_DATA'
+        CLEAR_PROCESS_DATA: 'CLEAR_PROCESS_DATA',
+        FETCH_PROCESS_ERROR: 'FETCH_PROCESS_ERROR'
     };
     const defaultState = { working: false, messageText: '', messageVisible: false };
     const generatedReducer = processStoreFactory(
@@ -103,6 +104,25 @@ describe('item store reducer factory', () => {
             messageVisible: false,
             working: false,
             data: null
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when process errors', () => {
+        const state = {
+            working: true
+        };
+
+        const action = {
+            type: actionTypes.FETCH_PROCESS_ERROR,
+            payload: null
+        };
+
+        const expected = {
+            working: false
         };
 
         deepFreeze(state);

--- a/src/reducers/reducerFactories/processStoreFactory.js
+++ b/src/reducers/reducerFactories/processStoreFactory.js
@@ -51,6 +51,12 @@
                     data: null
                 };
 
+            case actionTypes[`FETCH_${itemRoot}_ERROR`]:
+                return {
+                    ...state,
+                    working: false
+                };
+
             default:
         }
 


### PR DESCRIPTION
- I know the ProcessResult tracks success or failure of a process for you to act upon, but this just catches when the actual request to start a process fails before a ProcessResult can be built. Currently the loading spinner just spins forever in these cases so this just stops that happening.