### PR TITLE
add post By Href to updateApiActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [13.4.1] - 2022-03-09
+### Changes
+- Add postByHref to updateApiActions
 ## [13.4.0] - 2022-02-21
 ### Changes
 - Support optional externalLink field on individual drill downs in ReportTable DisplayUtilites.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "13.4.0",
+    "version": "13.4.1",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"

--- a/src/actions/UpdateApiActions.js
+++ b/src/actions/UpdateApiActions.js
@@ -109,6 +109,23 @@ export default function UpdateApiActions(
         }
     });
 
+    this.postByHref = href => ({
+        [RSAA]: {
+            endpoint: `${appRoot}${href}`,
+            method: 'POST',
+            options: { requiresAuth: true },
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+            },
+            types: [
+                rsaaTypes.requestPost(actionTypes, actionTypeRoot),
+                rsaaTypes.receivePost(actionTypes, actionTypeRoot, itemName),
+                rsaaTypes.error(actionTypes, actionTypeRoot, itemName)
+            ]
+        }
+    });
+
     this.delete = (id, item) => ({
         [RSAA]: {
             endpoint: id !== null ? `${appRoot}${uri}/${id}` : `${appRoot}${uri}`,

--- a/src/actions/rsaaTypes.js
+++ b/src/actions/rsaaTypes.js
@@ -73,6 +73,16 @@ export const receiveSearch = (actionTypes, actionTypeRoot, itemName) => ({
     payload: successPayload(itemName)
 });
 
+export const requestPost = (actionTypes, actionTypeRoot) => ({
+    type: actionTypes[`REQUEST_POST_${actionTypeRoot}`],
+    payload: {}
+});
+
+export const receivePost = (actionTypes, actionTypeRoot, itemName) => ({
+    type: actionTypes[`RECEIVE_POST_${actionTypeRoot}`],
+    payload: successPayload(itemName)
+});
+
 export const error = (actionTypes, actionTypeRoot, itemName) => ({
     type: actionTypes[`FETCH_${actionTypeRoot}_ERROR`],
     payload: async (action, state, res) =>


### PR DESCRIPTION
post by href for max flexibility? Or something in processActions? 
Do I need the new rsaaTypes or just use request and receive?