### PR TITLE
add handleReturnPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [13.9.0] - 2022-05-13
+### Changes
+- Add handle Return press option to Typeahead. Requires modal, openModalOnClick={false} handleFieldChange={} handleReturnPress={}
+- If handleReturnPress is not supplied then behaviour of Typeahead should be as before
 ## [13.8.1] - 2022-04-28
 ### Changes
 - Update PATCH Endpoint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "13.8.2",
+    "version": "13.9.0",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"


### PR DESCRIPTION
if you provide handleReturnPress then 
- the search icon is moved outside the input field as a visual cue
- handleReturnPress will be called when you press return
- modal search will work as normal when you press the icon (and start search with whatever is already typed)

If you don't provide handleReturnPress then no functionality will change 