### PR TITLE
Update collections reducer cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [13.11.0] - 2022-05-23
+### Changes
+- Add cases to allow updating collections to collectionStoreFactory
+- Add missing itemStoreFactory tests
 ## [13.10.0] - 2022-05-16
 ### Changes
 - Add FileUploader component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "13.10.0",
+    "version": "13.11.0",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"

--- a/src/reducers/__tests__/collectionStoreFactory.js
+++ b/src/reducers/__tests__/collectionStoreFactory.js
@@ -7,7 +7,11 @@ describe('collection store reducer factory', () => {
         RECEIVE_ENTITIES: 'RECEIVE_ENTITIES',
         REQUEST_APPLICATION_STATE_ENTITIES: 'REQUEST_APPLICATION_STATE_ENTITIES',
         RECEIVE_APPLICATION_STATE_ENTITIES: 'RECEIVE_APPLICATION_STATE_ENTITIES',
-        CLEAR_ENTITIES_DATA: 'CLEAR_ENTITIES_DATA'
+        CLEAR_ENTITIES_DATA: 'CLEAR_ENTITIES_DATA',
+        REQUEST_UPDATE_ENTITIES: 'REQUEST_UPDATE_ENTITIES',
+        RECEIVE_UPDATED_ENTITIES: 'RECEIVE_UPDATED_ENTITIES',
+        SHOW_ENTITIES_SNACKBAR: 'SHOW_ENTITIES_SNACKBAR',
+        HIDE_ENTITIES_SNACKBAR: 'HIDE_ENTITIES_SNACKBAR'
     };
     const defaultState = {
         loading: false,
@@ -109,6 +113,89 @@ describe('collection store reducer factory', () => {
             loading: false,
             items: null,
             applicationState: { links: [{ rel: 'create', href: '/create' }], loading: false }
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when requesting update entities', () => {
+        const state = {
+            loading: false
+        };
+
+        const action = {
+            type: actionTypes.REQUEST_UPDATE_ENTITIES,
+            payload: {}
+        };
+
+        const expected = {
+            loading: true
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when receiving updated entities', () => {
+        const state = {
+            loading: true,
+            items: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_UPDATED_ENTITIES,
+            payload: { data: [{ name: '1' }] }
+        };
+
+        const expected = {
+            loading: false,
+            items: [{ name: '1' }],
+            snackbarVisible: true
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when showing snackbar', () => {
+        const state = {
+            ...defaultState,
+            snackbarVisible: false
+        };
+
+        const action = {
+            type: actionTypes.SHOW_ENTITIES_SNACKBAR,
+            payload: {}
+        };
+
+        const expected = {
+            ...defaultState,
+            snackbarVisible: true
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when hiding snackbar', () => {
+        const state = {
+            ...defaultState,
+            snackbarVisible: true
+        };
+
+        const action = {
+            type: actionTypes.HIDE_ENTITIES_SNACKBAR,
+            payload: {}
+        };
+
+        const expected = {
+            ...defaultState,
+            snackbarVisible: false
         };
 
         deepFreeze(state);

--- a/src/reducers/__tests__/itemStoreFactory.js
+++ b/src/reducers/__tests__/itemStoreFactory.js
@@ -6,9 +6,11 @@ describe('item store reducer factory', () => {
         REQUEST_ENTITY: 'REQUEST_ENTITY',
         RESET_ENTITY: 'RESET_ENTITY',
         REQUEST_UPDATE_ENTITY: 'REQUEST_UPDATE_ENTITY',
+        REQUEST_UPDATED_ENTITY: 'REQUEST_UPDATE_ENTITY',
         REQUEST_ADD_ENTITY: 'REQUEST_ADD_ENTITY',
         RECEIVE_ENTITY: 'RECEIVE_ENTITY',
         RECEIVE_NEW_ENTITY: 'RECEIVE_NEW_ENTITY',
+        RECEIVE_UPDATED_ENTITY: 'RECEIVE_UPDATED_ENTITY',
         REQUEST_APPLICATION_STATE_ENTITY: 'REQUEST_APPLICATION_STATE_ENTITY',
         RECEIVE_APPLICATION_STATE_ENTITY: 'RECEIVE_APPLICATION_STATE_ENTITY',
         CLEAR_ENTITY_DATA: 'CLEAR_ENTITY_DATA',
@@ -335,6 +337,29 @@ describe('item store reducer factory', () => {
         const expected = {
             ...defaultState,
             snackbarVisible: false
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when receiving updated entity', () => {
+        const state = {
+            loading: true,
+            item: null
+        };
+
+        const action = {
+            type: actionTypes.RECEIVE_UPDATED_ENTITY,
+            payload: { data: { name: '1' } }
+        };
+
+        const expected = {
+            loading: false,
+            item: { name: '1' },
+            editStatus: 'view',
+            snackbarVisible: true
         };
 
         deepFreeze(state);

--- a/src/reducers/__tests__/itemStoreFactory.js
+++ b/src/reducers/__tests__/itemStoreFactory.js
@@ -15,7 +15,9 @@ describe('item store reducer factory', () => {
         REQUEST_POST_ENTITY: 'REQUEST_POST_ENTITY',
         RECEIVE_POST_ENTITY: 'RECEIVE_POST_ENTITY',
         REQUEST_PATCH_ENTITY: 'REQUEST_PATCH_ENTITY',
-        RECEIVE_PATCH_ENTITY: 'RECEIVE_PATCH_ENTITY'
+        RECEIVE_PATCH_ENTITY: 'RECEIVE_PATCH_ENTITY',
+        SHOW_ENTITY_SNACKBAR: 'SHOW_ENTITY_SNACKBAR',
+        HIDE_ENTITY_SNACKBAR: 'HIDE_ENTITY_SNACKBAR'
     };
     const defaultState = {
         loading: false,
@@ -291,6 +293,48 @@ describe('item store reducer factory', () => {
             item: { name: '1' },
             editStatus: 'view',
             snackbarVisible: true
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when showing snackbar', () => {
+        const state = {
+            ...defaultState,
+            snackbarVisible: false
+        };
+
+        const action = {
+            type: actionTypes.SHOW_ENTITY_SNACKBAR,
+            payload: {}
+        };
+
+        const expected = {
+            ...defaultState,
+            snackbarVisible: true
+        };
+
+        deepFreeze(state);
+
+        expect(generatedReducer(state, action)).toEqual(expected);
+    });
+
+    test('when hiding snackbar', () => {
+        const state = {
+            ...defaultState,
+            snackbarVisible: true
+        };
+
+        const action = {
+            type: actionTypes.HIDE_ENTITY_SNACKBAR,
+            payload: {}
+        };
+
+        const expected = {
+            ...defaultState,
+            snackbarVisible: false
         };
 
         deepFreeze(state);

--- a/src/reducers/reducerFactories/collectionStoreFactory.js
+++ b/src/reducers/reducerFactories/collectionStoreFactory.js
@@ -66,6 +66,28 @@ export default function(
                     ...state,
                     loading: false
                 };
+            case actionTypes[`REQUEST_UPDATE_${itemRoot}`]:
+                return {
+                    ...state,
+                    loading: true
+                };
+            case actionTypes[`RECEIVE_UPDATED_${itemRoot}`]:
+                return {
+                    ...state,
+                    loading: false,
+                    items: action.payload.data,
+                    snackbarVisible: true
+                };
+            case actionTypes[`SHOW_${itemRoot}_SNACKBAR`]:
+                return {
+                    ...state,
+                    snackbarVisible: true
+                };
+            case actionTypes[`HIDE_${itemRoot}_SNACKBAR`]:
+                return {
+                    ...state,
+                    snackbarVisible: false
+                };
             default:
         }
 


### PR DESCRIPTION
- support UPDATE_ENTITIES type actions in the collectionStoreFactory
- basically catches dispatched updates (PUT requests) to collections and updates state accordingly
- also noticed the itemStoreFactory was missing some tests, so added em