### PR TITLE
fix bugs with invisible components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [17.2.1] - 2023-01-11 
+### Changes
+- fix InputField and Search component autoFocus bugs that resulted from visibility of componenets - you can't autoFocus an input that's invisible which is the case when, for example, the input is in a modal that is currently closed - so needed some way to track the visibility of the input to implement the correct autoFocus behaviour.
 ## [17.2.0] - 2023-01-10 
 ### Changes
 - add autofocus prop to Search component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "17.2.0",
+    "version": "17.2.1",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -53,12 +53,19 @@ function InputField({
     decimalPlaces,
     textFieldProps,
     autoFocus,
-    onErrorStateChange
+    onErrorStateChange,
+    visible
 }) {
     const classes = useStyles();
     const inputRef = useRef();
     const [inErrorState, setInErrorState] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
+    useEffect(() => {
+        if (!autoFocus || !inputRef.current || !visible) return;
+        setTimeout(() => {
+            inputRef.current.focus();
+        }, 100);
+    }, [autoFocus, visible]);
 
     useEffect(() => {
         setInErrorState(error);
@@ -97,7 +104,6 @@ function InputField({
 
         onChange(propertyName, val);
     };
-
     return (
         <>
             <InputLabel
@@ -134,7 +140,6 @@ function InputField({
                 value={type === 'date' ? moment(value).format('YYYY-MM-DD') : getValue(value)}
                 onChange={e => change(e)}
                 InputProps={{
-                    autoFocus,
                     startAdornment: adornment ? (
                         <InputAdornment position="start">{adornment}</InputAdornment>
                     ) : null,
@@ -180,7 +185,8 @@ InputField.propTypes = {
     decimalPlaces: PropTypes.number,
     textFieldProps: PropTypes.shape({}),
     autoFocus: PropTypes.bool,
-    onErrorStateChange: PropTypes.func
+    onErrorStateChange: PropTypes.func,
+    visible: PropTypes.bool
 };
 
 InputField.defaultProps = {
@@ -202,7 +208,8 @@ InputField.defaultProps = {
     decimalPlaces: null,
     textFieldProps: null,
     autoFocus: false,
-    onErrorStateChange: null
+    onErrorStateChange: null,
+    visible: true
 };
 
 export default InputField;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -46,7 +46,8 @@ function Search({
     searchOnEnter,
     onKeyPressFunctions,
     helperText,
-    autoFocus
+    autoFocus,
+    visible
 }) {
     const classes = useStyles();
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -149,6 +150,7 @@ function Search({
     return (
         <>
             <InputField
+                visible={visible}
                 value={value}
                 propertyName={propertyName}
                 label={label}
@@ -214,7 +216,8 @@ Search.propTypes = {
     onKeyPressFunctions: PropTypes.arrayOf(
         PropTypes.shape({ keyCode: PropTypes.number, action: PropTypes.func })
     ),
-    helperText: PropTypes.string
+    helperText: PropTypes.string,
+    visible: PropTypes.bool
 };
 Search.defaultProps = {
     searchOnEnter: true,
@@ -227,7 +230,8 @@ Search.defaultProps = {
     priorityFunction: null,
     resultLimit: null,
     resultsInModal: false,
-    helperText: 'PRESS ENTER TO SEARCH'
+    helperText: 'PRESS ENTER TO SEARCH',
+    visible: true
 };
 
 export default Search;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -222,7 +222,7 @@ Search.propTypes = {
 Search.defaultProps = {
     searchOnEnter: true,
     onKeyPressFunctions: [],
-    autoFocus: false,
+    autoFocus: true,
     value: null,
     disabled: false,
     searchResults: [],

--- a/src/stories/InputField.stories.js
+++ b/src/stories/InputField.stories.js
@@ -32,6 +32,18 @@ LabelAndValue.args = {
     label: 'Input Field'
 };
 
+export const AutoFocus = args => <InputField {...args} {...actions} />;
+
+AutoFocus.story = {
+    name: 'AutoFocus'
+};
+
+AutoFocus.args = {
+    value: 'Value',
+    label: 'Input Field',
+    autoFocus: true
+};
+
 export const LabelNoValue = args => <InputField {...args} {...actions} />;
 
 LabelNoValue.story = {

--- a/src/stories/Search.stories.js
+++ b/src/stories/Search.stories.js
@@ -59,6 +59,27 @@ ResultsInline.args = {
     ...defaultArgs
 };
 
+export const AutoFocus = args => {
+    const [value, setValue] = useState('result');
+    return (
+        <Search
+            {...args}
+            {...actions}
+            value={value}
+            autoFocus
+            handleValueChange={(_, newValue) => setValue(newValue)}
+        />
+    );
+};
+
+AutoFocus.story = {
+    name: 'AutoFocus'
+};
+
+AutoFocus.args = {
+    ...defaultArgs
+};
+
 export const ResultsInModal = args => {
     const [value, setValue] = useState('result');
     return (


### PR DESCRIPTION
 - my last PR didn't work since the Search I'm rendering is in a modal and so is invisible when the component mounts and as such its input element can't be focused
 - so this is a manual work around that runs an effect when the components visibility changes in order to focus the input
 - the timeout is to account for a short delay between the modal's open flag switching to true and the input actually being visible for real