### PR TITLE
export the dumb/presentational component of Navigation to allow it to  be used outside of redux store providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [19.1.0] - 2024-03-27
+### Changes
+- Export the Navigation presentational component as 'NavigationUI'. Currently only the container is exported as 'Navigation', which contains all of the data-fetching/redux logic.
 ## [19.0.0] - 2024-02-18
 ### Changes
 - Rework the AddressUtility to handle looking up existing addresses as well as creating new ones. Now also handles its own Dialog open/closed state, and seperates the redux data fetching container from the presentational component to allow it to be reusable in future apps that might not use redux.

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ import userSelectors from './src/selectors/userSelectors';
 import utilities from './src/utilities/index';
 import initialiseOnMount from './src/components/common/initialiseOnMount';
 import Navigation from './src/containers/Navigation';
+import NavigationUI from './src/components/Navigation';
+
 import {
     getItemError,
     getRequestErrors,
@@ -137,6 +139,7 @@ export {
     menuSelectors,
     MultiReportTable,
     Navigation,
+    NavigationUI,
     news,
     newsSelectors,
     NotFound,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "19.0.0",
+    "version": "19.1.0",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,7 +67,7 @@ export default [
             reportResultsFactory: 'src/reducers/reducerFactories/reportResultsFactory.js',
             utilities: 'src/utilities/index.js',
             Navigation: 'src/containers/Navigation.js',
-            NavigationUI: '/src/components/Navigation',
+            NavigationUI: 'src/components/Navigation',
             fetchMenu: 'src/actions/fetchMenu.js',
             fetchNews: 'src/actions/fetchNews.js',
             menu: 'src/reducers/menu.js',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,6 +67,7 @@ export default [
             reportResultsFactory: 'src/reducers/reducerFactories/reportResultsFactory.js',
             utilities: 'src/utilities/index.js',
             Navigation: 'src/containers/Navigation.js',
+            NavigationUI: '/src/components/Navigation',
             fetchMenu: 'src/actions/fetchMenu.js',
             fetchNews: 'src/actions/fetchNews.js',
             menu: 'src/reducers/menu.js',


### PR DESCRIPTION
- this is just so I can use it in non-redux apps
- although to be honest it could do with a bit of a rewrite... my react skills have progressed quite a bit since I first made it