### PR TITLE
support page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [19.6.0] - 2024-09-03
+### Changes
+- Add optional title string prop to the page component, to allow easily setting the pages title (i.e. the thing that will appear in the browser tab)
 ## [19.5.0] - 2024-08-26
 ### Changes
 - Add extra optional 'listFieldName' to collectionStoreFactory, to allow reducers it returns to cope with responses, i.e. the payload.data of the RECEIVE_... action, that are not straight lists. I.e. they are objects, where the array containing the data of interest lives at payload.data[listFieldName] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [19.6.0] - 2024-09-03
 ### Changes
-- Add optional title string prop to the page component, to allow easily setting the pages title (i.e. the thing that will appear in the browser tab)
+- Add optional title string prop to the page component, to allow easily setting the pages title (i.e. the thing that will appear in the browser tab). Also supports an optional additional defaultAppTitle string prop, which will be reverted to when the component unmounts (if passed)
 ## [19.5.0] - 2024-08-26
 ### Changes
 - Add extra optional 'listFieldName' to collectionStoreFactory, to allow reducers it returns to cope with responses, i.e. the payload.data of the RECEIVE_... action, that are not straight lists. I.e. they are objects, where the array containing the data of interest lives at payload.data[listFieldName] 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linn-it/linn-form-components-library",
-    "version": "19.5.0",
+    "version": "19.6.0",
     "private": false,
     "jest": {
         "testEnvironment": "jsdom"

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -46,7 +46,8 @@ function Page({
     showRequestErrors,
     homeUrl,
     showBreadcrumbs,
-    title
+    title,
+    defaultAppTitle
 }) {
     const classes = useStyles();
     const { enqueueSnackbar } = useSnackbar();
@@ -66,6 +67,11 @@ function Page({
         if (title) {
             document.title = title;
         }
+        return () => {
+            if (defaultAppTitle) {
+                document.title = defaultAppTitle;
+            }
+        };
     }, [title]);
 
     return (
@@ -95,7 +101,8 @@ Page.propTypes = {
     requestErrors: PropTypes.arrayOf(PropTypes.shape({})),
     homeUrl: PropTypes.string,
     showBreadcrumbs: PropTypes.bool,
-    title: PropTypes.string
+    title: PropTypes.string,
+    defaultAppTitle: PropTypes.string
 };
 
 Page.defaultProps = {
@@ -104,7 +111,8 @@ Page.defaultProps = {
     requestErrors: [],
     homeUrl: null,
     showBreadcrumbs: true,
-    title: null
+    title: null,
+    defaultAppTitle: null
 };
 
 export default Page;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -2,7 +2,7 @@ import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';
 import makeStyles from '@mui/styles/makeStyles';
 import { useSnackbar } from 'notistack';
-import React, { Fragment, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Breadcrumbs from './Breadcrumbs';
 
@@ -45,7 +45,8 @@ function Page({
     requestErrors,
     showRequestErrors,
     homeUrl,
-    showBreadcrumbs
+    showBreadcrumbs,
+    title
 }) {
     const classes = useStyles();
     const { enqueueSnackbar } = useSnackbar();
@@ -61,24 +62,28 @@ function Page({
         }
     }, [requestErrors, enqueueSnackbar]);
 
-    return (
-        <>
-            <Grid container spacing={3} className={classes.grid}>
-                <Grid item xs={1} />
-                <Grid item xs={10} className="hide-when-printing">
-                    {showBreadcrumbs && <Breadcrumbs history={history} homeUrl={homeUrl} />}
-                </Grid>
-                <Grid item xs={1} />
+    useEffect(() => {
+        if (title) {
+            document.title = title;
+        }
+    }, [title]);
 
-                <Grid item xs={columnWidth[width]} />
-                <Grid item xs={pageWidth[width]}>
-                    <Paper className={classes.root} square>
-                        {children}
-                    </Paper>
-                </Grid>
-                <Grid item xs={columnWidth[width]} />
+    return (
+        <Grid container spacing={3} className={classes.grid}>
+            <Grid item xs={1} />
+            <Grid item xs={10} className="hide-when-printing">
+                {showBreadcrumbs && <Breadcrumbs history={history} homeUrl={homeUrl} />}
             </Grid>
-        </>
+            <Grid item xs={1} />
+
+            <Grid item xs={columnWidth[width]} />
+            <Grid item xs={pageWidth[width]}>
+                <Paper className={classes.root} square>
+                    {children}
+                </Paper>
+            </Grid>
+            <Grid item xs={columnWidth[width]} />
+        </Grid>
     );
 }
 
@@ -89,7 +94,8 @@ Page.propTypes = {
     showRequestErrors: PropTypes.bool,
     requestErrors: PropTypes.arrayOf(PropTypes.shape({})),
     homeUrl: PropTypes.string,
-    showBreadcrumbs: PropTypes.bool
+    showBreadcrumbs: PropTypes.bool,
+    title: PropTypes.string
 };
 
 Page.defaultProps = {
@@ -97,7 +103,8 @@ Page.defaultProps = {
     showRequestErrors: false,
     requestErrors: [],
     homeUrl: null,
-    showBreadcrumbs: true
+    showBreadcrumbs: true,
+    title: null
 };
 
 export default Page;


### PR DESCRIPTION
just lets you easily change the string that appears in the browser tab to reflect what page the tab is currently rendering 
