### PR TITLE
change show row count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## [31.2.1] - 2025-09-16
+- ReportDataGrid - change showRowCount option to display below the grid.
 ## [31.2.0] - 2025-09-11
 - ReportDataGrid, ReportDataGrids - add showRowCount option. Per report using Datagrid footer.
 ## [31.1.5] - 2025-09-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linn-it/linn-form-components-library",
-  "version": "31.2.0",
+  "version": "31.2.1",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/ReportDataGrid.js
+++ b/src/components/ReportDataGrid.js
@@ -176,7 +176,7 @@ function ReportDataGrid({
                     getRowHeight={() => (fixedRowHeight ? 30 : 'auto')}
                     disableRowSelectionOnClick
                     getRowClassName={getRowClass}
-                    hideFooter={report.results.length <= 100 && !showRowCount}
+                    hideFooter={report.results.length <= 100}
                     sx={{
                         [`& .${gridClasses.cell}`]: {
                             py: 1,
@@ -194,6 +194,19 @@ function ReportDataGrid({
                     }}
                 />
             </Grid>
+            {showRowCount && report && report.results && (
+                <Grid size={12} sx={{ marginTop: '-10px' }}>
+                    <Typography
+                        variant="body2"
+                        style={{
+                            float: 'left',
+                            paddingLeft: '15px'
+                        }}
+                    >
+                        Number of rows: {report.results.length}
+                    </Typography>
+                </Grid>
+            )}
         </Grid>
     );
 }

--- a/src/components/ReportDataGrid.js
+++ b/src/components/ReportDataGrid.js
@@ -195,12 +195,12 @@ function ReportDataGrid({
                 />
             </Grid>
             {showRowCount && report && report.results && (
-                <Grid size={12} sx={{ marginTop: '-10px' }}>
+                <Grid size={12} sx={{ mt: -1.25 }}>
                     <Typography
                         variant="body2"
-                        style={{
+                        sx={{
                             float: 'left',
-                            paddingLeft: '15px'
+                            pl: 2
                         }}
                     >
                         Number of rows: {report.results.length}


### PR DESCRIPTION
Datagrid row count does not work when there are totals and/or subtotals in the grid.